### PR TITLE
Remove unused react-native-opencv3 dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "react-dom": "^19.0.0",
         "react-native": "0.79.2",
         "react-native-gesture-handler": "~2.24.0",
-        "react-native-opencv3": "^1.0.8",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.10.0",
         "react-native-svg": "^15.11.2",
@@ -8486,16 +8485,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/react-native-opencv3": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/react-native-opencv3/-/react-native-opencv3-1.0.8.tgz",
-      "integrity": "sha512-v+tiiAtP0HAks7EwznmHvgMtdabAjJOURzmdV5OKSQpmf2zHHDyuCr5N3G3tX24x80wRX0YGpE4N4vh5lonegQ==",
-      "license": "BSD",
-      "peerDependencies": {
-        "react-native": "0.59.5",
-        "react-native-fs": "^2.13.3"
       }
     },
     "node_modules/react-native-safe-area-context": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "react-dom": "^19.0.0",
     "react-native": "0.79.2",
     "react-native-gesture-handler": "~2.24.0",
-    "react-native-opencv3": "^1.0.8",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",
     "react-native-svg": "^15.11.2",


### PR DESCRIPTION
## Summary
- remove `react-native-opencv3` from dependencies and lock file

## Testing
- `npm install --legacy-peer-deps`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684afa4ce1ac8333ab73737e73479ece