### PR TITLE
Add error handling for OpenCV image loading

### DIFF
--- a/assets/opencv.html
+++ b/assets/opencv.html
@@ -80,6 +80,14 @@ window.ReactNativeWebView.postMessage(JSON.stringify({
   contour: points
 }));
           };
+          img.onerror = () => {
+            window.ReactNativeWebView.postMessage(
+              JSON.stringify({
+                type: 'error',
+                message: 'Image load failed'
+              })
+            );
+          };
           img.src = 'data:image/png;base64,' + imageData;
         } catch (e) {
           window.ReactNativeWebView.postMessage(JSON.stringify({

--- a/components/OpenCVWorker.tsx
+++ b/components/OpenCVWorker.tsx
@@ -67,6 +67,11 @@ const OpenCVWorker = forwardRef((props: Props, ref) => {
       return;
     }
 
+    if (parsed?.type === 'error') {
+      console.error(`OpenCV error: ${parsed.message}`);
+      return;
+    }
+
     if (parsed === null) {
       console.error('Ошибка WebView: неверный формат сообщения');
     }


### PR DESCRIPTION
## Summary
- handle image load failure in `assets/opencv.html`
- report errors from WebView to console in `OpenCVWorker`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b2333df2083338b350ae2aab7c38f