### PR TITLE
Add parameter validation to processImage

### DIFF
--- a/assets/opencv.html
+++ b/assets/opencv.html
@@ -21,6 +21,13 @@
       }
 
       window.processImage = function(imageData, width, height, pxPerCell) {
+        if (typeof width !== 'number' || typeof height !== 'number' || typeof pxPerCell !== 'number' ||
+            width <= 0 || height <= 0 || pxPerCell <= 0) {
+          window.ReactNativeWebView.postMessage(
+            JSON.stringify({ type: 'error', message: 'Invalid parameters' })
+          );
+          return;
+        }
         try {
           let img = new Image();
           img.onload = () => {


### PR DESCRIPTION
## Summary
- validate `width`, `height` and `pxPerCell` in `processImage`
- return an error message if values are not positive numbers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b261001748333a85edc18657bfaa1