### PR TITLE
Compute dynamic scale from marker

### DIFF
--- a/assets/opencv.html
+++ b/assets/opencv.html
@@ -56,6 +56,7 @@
             cv.findContours(edges, contours, hierarchy, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE);
             let contourCount = contours.size();
             let markerFound = false;
+            let calculatedPxPerCell = pxPerCell;
 
             for (let i = 0; i < contours.size(); ++i) {
               const cnt = contours.get(i);
@@ -81,10 +82,13 @@
                   areaR < pxPerCell * pxPerCell * 2
                 ) {
                   markerFound = true;
+                  calculatedPxPerCell = Math.sqrt(areaR);
                   break;
                 }
               }
             }
+
+            pxPerCell = calculatedPxPerCell;
 
             if (debug) {
               ctx.lineWidth = 2;
@@ -117,19 +121,18 @@
               }
             }
 
-            let mm2 = maxArea * (25.0 / (pxPerCell * pxPerCell));
-            let cm2 = mm2 / 100.0;
-            let result = Math.round(cm2 * 100) / 100;
+            let result = maxArea;
 
             src.delete(); gray.delete(); edges.delete();
             contours.delete(); hierarchy.delete();
-window.ReactNativeWebView.postMessage(JSON.stringify({
-  type: 'result',
-  area: result,
-  contour: points,
-  contourCount: contourCount,
-  markerFound: markerFound
-}));
+  window.ReactNativeWebView.postMessage(JSON.stringify({
+    type: 'result',
+    area: result,
+    pxPerCell: pxPerCell,
+    contour: points,
+    contourCount: contourCount,
+    markerFound: markerFound
+  }));
           };
           img.onerror = () => {
             window.ReactNativeWebView.postMessage(

--- a/components/OpenCVWorker.tsx
+++ b/components/OpenCVWorker.tsx
@@ -12,6 +12,7 @@ type Props = {
   onResult?: (
     result: {
       area: number;
+      pxPerCell: number;
       contour: { x: number; y: number }[];
       contourCount: number;
       markerFound: boolean;
@@ -77,6 +78,7 @@ const OpenCVWorker = forwardRef((props: Props, ref) => {
     if (parsed?.type === 'result') {
       props.onResult?.({
         area: parsed.area,
+        pxPerCell: parsed.pxPerCell,
         contour: parsed.contour,
         contourCount: parsed.contourCount,
         markerFound: parsed.markerFound,

--- a/utils/leaf-analyzer.tsx
+++ b/utils/leaf-analyzer.tsx
@@ -56,12 +56,20 @@ export class OpenCvAnalyzer implements LeafAnalyzer {
 
   handleResult(res: {
     area: number;
+    pxPerCell: number;
     contour: Point[];
     contourCount: number;
     markerFound: boolean;
   }) {
     const item = this.queue.shift();
-    item?.resolve(res);
+    const cm2 =
+      (res.area * (25.0 / (res.pxPerCell * res.pxPerCell))) / 100.0;
+    item?.resolve({
+      area: cm2,
+      contour: res.contour,
+      contourCount: res.contourCount,
+      markerFound: res.markerFound,
+    });
     if (this.queue.length > 0) {
       const next = this.queue[0];
       this.webRef.current?.sendImage(next.base64, next.width, next.height, 30);
@@ -156,6 +164,7 @@ export const LeafAnalyzerProvider = ({ children }: { children: React.ReactNode }
   const onResult = (
     res: {
       area: number;
+      pxPerCell: number;
       contour: Point[];
       contourCount: number;
       markerFound: boolean;


### PR DESCRIPTION
## Summary
- compute marker size in `opencv.html`
- send computed `pxPerCell` back to React Native
- expose new field from `OpenCVWorker`
- use returned scale in `OpenCvAnalyzer` when calculating area

## Testing
- `npm run tsc` *(fails: Cannot find module 'zustand', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684b36d29f088333b380de5d6fc5e80a