### PR TITLE
Add analyzer queue cleanup

### DIFF
--- a/utils/leaf-analyzer.tsx
+++ b/utils/leaf-analyzer.tsx
@@ -9,7 +9,7 @@ import * as FileSystem from "expo-file-system";
 import { Image, Alert, ActivityIndicator, View, Text, StyleSheet } from "react-native";
 import OpenCVWorker, { OpenCVHandle } from "@/components/OpenCVWorker";
 import { analyzeLeafArea, findLeafContour } from "@/utils/camera-utils";
-import React, { createContext, useContext, useMemo, useRef, useState } from "react";
+import React, { createContext, useContext, useMemo, useRef, useState, useEffect } from "react";
 import Colors from "@/constants/colors";
 import { Platform } from "react-native";
 
@@ -107,6 +107,10 @@ export class OpenCvAnalyzer implements LeafAnalyzer {
     }
   }
 
+  clearQueue() {
+    this.queue = [];
+  }
+
   private async process(
     imageUri: string,
     isLive: boolean,
@@ -158,6 +162,14 @@ export const LeafAnalyzerProvider = ({ children }: { children: React.ReactNode }
     }
     return new OpenCvAnalyzer(webRef);
   }, []);
+
+  useEffect(() => {
+    return () => {
+      if (analyzer instanceof OpenCvAnalyzer) {
+        analyzer.clearQueue();
+      }
+    };
+  }, [analyzer]);
 
   const [isOpenCvReady, setIsOpenCvReady] = useState(Platform.OS === "web");
 


### PR DESCRIPTION
## Summary
- cleanup analyzer queue when LeafAnalyzerProvider unmounts
- create `clearQueue` method in `OpenCvAnalyzer`

## Testing
- `npm run tsc` *(fails: Cannot find module '@/constants/colors' ...)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b3a5215608333bc9c3ea924319ced