### PR TITLE
Добавить ожидание готовности OpenCV

### DIFF
--- a/assets/opencv.html
+++ b/assets/opencv.html
@@ -25,6 +25,7 @@
           window.ReactNativeWebView.postMessage(
             JSON.stringify({ type: 'ready' })
           );
+          window.ReactNativeWebView.postMessage('ready');
         };
       }
 

--- a/utils/leaf-analyzer.tsx
+++ b/utils/leaf-analyzer.tsx
@@ -234,7 +234,7 @@ export const useLeafAnalyzer = () => useContext(LeafAnalyzerContext);
 const styles = StyleSheet.create({
   initOverlay: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.5)',
+    backgroundColor: 'rgba(0,0,0,0.6)',
     justifyContent: 'center',
     alignItems: 'center',
     zIndex: 100,
@@ -242,5 +242,7 @@ const styles = StyleSheet.create({
   initText: {
     marginTop: 8,
     color: Colors.text.primary,
+    fontSize: 16,
+    fontWeight: '500',
   },
 });


### PR DESCRIPTION
## Summary
- send `ready` message from `opencv.html`
- show indicator in `OpenCVWorker` until library loaded
- tweak overlay styles in `LeafAnalyzerProvider`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b57bfc52c833393680f7bdb68e9d8