### PR TITLE
Add store and analyzer tests

### DIFF
--- a/__tests__/LeafAnalyzerProvider.test.tsx
+++ b/__tests__/LeafAnalyzerProvider.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { LeafAnalyzerProvider } from '../utils/leaf-analyzer';
+import * as analyzerModule from '../utils/leaf-analyzer';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+const mockSendImage = jest.fn();
+const mockWaitUntilReady = jest.fn(() => Promise.resolve());
+
+jest.mock('../components/OpenCVWorker', () => {
+  const React = require('react');
+  const { forwardRef, useImperativeHandle, useEffect } = React;
+  return forwardRef((props: any, ref) => {
+    useImperativeHandle(ref, () => ({
+      sendImage: mockSendImage,
+      waitUntilReady: mockWaitUntilReady,
+    }));
+    useEffect(() => {
+      props.onResult?.({
+        area: 5,
+        pxPerCell: 1,
+        contour: [],
+        contourCount: 0,
+        markerFound: true,
+      });
+    }, []);
+    return null;
+  });
+});
+
+describe('LeafAnalyzerProvider', () => {
+  it('handles result from WebView', async () => {
+    const spy = jest.spyOn(analyzerModule.OpenCvAnalyzer.prototype, 'handleResult');
+
+    render(
+      <LeafAnalyzerProvider>
+        <></>
+      </LeafAnalyzerProvider>
+    );
+
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+  });
+});

--- a/__tests__/leaf-store.test.ts
+++ b/__tests__/leaf-store.test.ts
@@ -1,0 +1,36 @@
+import { useLeafStore } from '../store/leaf-store';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+describe('leaf-store', () => {
+  beforeEach(() => {
+    useLeafStore.getState().clearAllImages();
+  });
+
+  it('adds and removes captured images', () => {
+    const image = {
+      id: '1',
+      uri: 'uri',
+      filename: 'file.jpg',
+      date: 'now',
+      leafArea: 1,
+      location: null,
+    };
+    const store = useLeafStore.getState();
+    store.addCapturedImage(image);
+    expect(useLeafStore.getState().capturedImages[0]).toEqual(image);
+
+    store.removeCapturedImage('1');
+    expect(useLeafStore.getState().capturedImages).toHaveLength(0);
+  });
+
+  it('clears all images', () => {
+    const store = useLeafStore.getState();
+    store.addCapturedImage({ id: '1', uri: 'a', filename: 'b', date: 'd', leafArea: 1, location: null });
+    store.addCapturedImage({ id: '2', uri: 'c', filename: 'e', date: 'd', leafArea: 2, location: null });
+    store.clearAllImages();
+    expect(useLeafStore.getState().capturedImages).toEqual([]);
+  });
+});

--- a/__tests__/settings-store.test.ts
+++ b/__tests__/settings-store.test.ts
@@ -1,0 +1,33 @@
+import { useSettingsStore } from '../store/settings-store';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+describe('settings-store', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({
+      highResolutionCapture: true,
+      saveGpsData: true,
+      manualFocusOnly: true,
+    });
+  });
+
+  it('toggles high resolution capture', () => {
+    const store = useSettingsStore.getState();
+    store.toggleHighResolutionCapture();
+    expect(useSettingsStore.getState().highResolutionCapture).toBe(false);
+  });
+
+  it('toggles saveGpsData', () => {
+    const store = useSettingsStore.getState();
+    store.toggleSaveGpsData();
+    expect(useSettingsStore.getState().saveGpsData).toBe(false);
+  });
+
+  it('toggles manualFocusOnly', () => {
+    const store = useSettingsStore.getState();
+    store.toggleManualFocusOnly();
+    expect(useSettingsStore.getState().manualFocusOnly).toBe(false);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: 'jest-expo',
-  moduleFileExtensions: ['ts', 'tsx', 'js']
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  setupFilesAfterEnv: ['@testing-library/react-native']
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,8 @@
       "devDependencies": {
         "@babel/core": "^7.25.2",
         "@expo/ngrok": "^4.1.0",
+        "@testing-library/jest-native": "^5.4.3",
+        "@testing-library/react-native": "^13.2.0",
         "@types/jest": "^29.5.11",
         "@types/react": "^19.1.8",
         "@types/react-native": "^0.72.8",
@@ -4029,6 +4031,53 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@testing-library/jest-native": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-native/-/jest-native-5.4.3.tgz",
+      "integrity": "sha512-/sSDGaOuE+PJ1Z9Kp4u7PQScSVVXGud59I/qsBFFJvIbcn4P6yYw6cBnBmbPF+X9aRIsTJRDl6gzw5ZkJNm66w==",
+      "deprecated": "DEPRECATED: This package is no longer maintained.\nPlease use the built-in Jest matchers available in @testing-library/react-native v12.4+.\n\nSee migration guide: https://callstack.github.io/react-native-testing-library/docs/migration/jest-matchers",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "jest-diff": "^29.0.1",
+        "jest-matcher-utils": "^29.0.1",
+        "pretty-format": "^29.0.3",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-native": ">=0.59",
+        "react-test-renderer": ">=16.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-13.2.0.tgz",
+      "integrity": "sha512-3FX+vW/JScXkoH8VSCRTYF4KCHC56y4AI6TMDISfLna6r+z8kaSEmxH1I6NVaFOxoWX9yaHDyI26xh7BykmqKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "jest-matcher-utils": "^29.7.0",
+        "pretty-format": "^29.7.0",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=18.2.0",
+        "react-native": ">=0.71",
+        "react-test-renderer": ">=18.2.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tootallnate/once": {
@@ -8031,6 +8080,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -10936,6 +10995,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -12677,6 +12746,20 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -13690,6 +13773,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@expo/ngrok": "^4.1.0",
+    "@testing-library/jest-native": "^5.4.3",
+    "@testing-library/react-native": "^13.2.0",
     "@types/jest": "^29.5.11",
     "@types/react": "^19.1.8",
     "@types/react-native": "^0.72.8",


### PR DESCRIPTION
## Summary
- add tests for leaf-store and settings-store
- test LeafAnalyzerProvider with mocked WebView result
- configure jest to load `@testing-library/react-native`
- include testing library dependencies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bbe2a94188333800e91e4a365fbbc