### PR TITLE
Внесено обновление в Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   preset: 'jest-expo',
   moduleFileExtensions: ['ts', 'tsx', 'js'],
+  moduleNameMapper: {
+    '^react-native$': 'react-native'
+  },
   setupFilesAfterEnv: ['@testing-library/react-native']
 };


### PR DESCRIPTION
## Summary
- обновлён `jest.config.js`: добавлен `moduleNameMapper` для корректного разрешения пакета `react-native`

## Testing
- `npm test` *(падает: _createJSONStorage is not a function_)*

------
https://chatgpt.com/codex/tasks/task_e_684bd8f6d75c833388376bfa3983df0c