### PR TITLE
Add webview error handling and bundle OpenCV assets

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,6 +37,10 @@
     ],
     "experiments": {
       "typedRoutes": true
-    }
+    },
+    "assetBundlePatterns": [
+      "assets/opencv.html",
+      "assets/opencv.js"
+    ]
   }
 }

--- a/assets/opencv.html
+++ b/assets/opencv.html
@@ -10,7 +10,7 @@
   </head>
   <body>
     <canvas id="canvas"></canvas>
-    <script async src="opencv.js" onload="onOpenCvReady();"></script>
+    <script async src="opencv.js" onload="onOpenCvReady();" onerror="onOpenCvError();"></script>
     <script>
       let debug = false;
       const params = new URLSearchParams(window.location.search);
@@ -27,6 +27,12 @@
           );
           window.ReactNativeWebView.postMessage('ready');
         };
+      }
+
+      function onOpenCvError() {
+        window.ReactNativeWebView.postMessage(
+          JSON.stringify({ type: 'error', message: 'Failed to load OpenCV script' })
+        );
       }
 
       window.processImage = function(imageData, width, height, pxPerCell) {

--- a/components/OpenCVWorker.tsx
+++ b/components/OpenCVWorker.tsx
@@ -129,6 +129,14 @@ const OpenCVWorker = forwardRef((props: Props, ref) => {
         originWhitelist={['*']}
         source={{ uri: `${htmlUri}${props.debug ? '?debug=true' : ''}` }}
         onMessage={handleMessage}
+        onError={(e) => {
+          console.error('Ошибка загрузки WebView:', e.nativeEvent);
+          props.onError?.('WebView error');
+        }}
+        onHttpError={(e) => {
+          console.error('HTTP ошибка WebView:', e.nativeEvent);
+          props.onError?.('WebView HTTP error');
+        }}
         javaScriptEnabled={true}
         style={styles.webview}
       />

--- a/metro.config.js
+++ b/metro.config.js
@@ -2,6 +2,9 @@ const { getDefaultConfig } = require('expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
 
+// Ensure HTML files are treated as assets
+config.resolver.assetExts.push('html');
+
 config.server = {
   ...config.server,
   enhanceMiddleware: (middleware) => {


### PR DESCRIPTION
## Summary
- include OpenCV HTML & JS in production build
- serve HTML as an asset via Metro config
- log WebView load errors
- send error message if OpenCV script fails to load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684be2a6931c83338042121b5712f602