### PR TITLE
Configure OpenCV URL via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ npx expo export -p web
 - **types/** – глобальные типы TypeScript;
 - конфигурационные файлы `metro.config.js`, `jest.config.js`, `tsconfig.json`.
 
+## Переменные окружения
+При необходимости можно переопределить адрес, с которого загружается страница
+с OpenCV. Для этого задайте переменную `EXPO_PUBLIC_BASE_URL`:
+```bash
+EXPO_PUBLIC_BASE_URL=192.168.1.10:8081 npm start
+```
+По умолчанию используется `localhost:8081`.
+
 ## Полезные npm‑скрипты
 Из файла `package.json`:
 ```json

--- a/components/LeafAnalyzer.tsx
+++ b/components/LeafAnalyzer.tsx
@@ -2,6 +2,7 @@
 import React, { useRef, useState } from 'react';
 import { View, Button, Text } from 'react-native';
 import { WebView, WebViewMessageEvent } from "react-native-webview";
+import { BASE_URL } from "@/constants/config";
 
 export default function LeafAnalyzer() {
   const webViewRef = useRef<WebView>(null);
@@ -42,7 +43,7 @@ export default function LeafAnalyzer() {
     <View style={{ flex: 1 }}>
       <WebView
         ref={webViewRef}
-        source={{ uri: `http://localhost:8081/opencv.html${debug ? '?debug=true' : ''}` }}
+        source={{ uri: `http://${BASE_URL}/opencv.html${debug ? '?debug=true' : ''}` }}
         onMessage={handleMessage}
         javaScriptEnabled={true}
         originWhitelist={['*']}

--- a/constants/config.ts
+++ b/constants/config.ts
@@ -1,0 +1,1 @@
+export const BASE_URL = process.env.EXPO_PUBLIC_BASE_URL ?? 'localhost:8081';


### PR DESCRIPTION
## Summary
- add `constants/config.ts` with `BASE_URL`
- use `BASE_URL` in `LeafAnalyzer`
- document `EXPO_PUBLIC_BASE_URL` in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ed93f6784833392d88e585792c0e8