### PR TITLE
Handle OpenCV initialization error

### DIFF
--- a/__tests__/LeafAnalyzerProvider.test.tsx
+++ b/__tests__/LeafAnalyzerProvider.test.tsx
@@ -5,7 +5,8 @@
  */
 import React from 'react';
 import { render, waitFor } from '@testing-library/react-native';
-import { LeafAnalyzerProvider } from '../utils/leaf-analyzer';
+import { Text } from 'react-native';
+import { LeafAnalyzerProvider, useLeafAnalyzer } from '../utils/leaf-analyzer';
 import * as analyzerModule from '../utils/leaf-analyzer';
 
 jest.mock('@react-native-async-storage/async-storage', () =>
@@ -14,6 +15,7 @@ jest.mock('@react-native-async-storage/async-storage', () =>
 
 const mockSendImage = jest.fn();
 const mockWaitUntilReady = jest.fn(() => Promise.resolve());
+(global as any).triggerError = false;
 
 jest.mock('../components/OpenCVWorker', () => {
   const React = require('react');
@@ -24,13 +26,17 @@ jest.mock('../components/OpenCVWorker', () => {
       waitUntilReady: mockWaitUntilReady,
     }));
     useEffect(() => {
-      props.onResult?.({
-        area: 5,
-        pxPerCell: 1,
-        contour: [],
-        contourCount: 0,
-        markerFound: true,
-      });
+      if ((global as any).triggerError) {
+        props.onError?.('load error');
+      } else {
+        props.onResult?.({
+          area: 5,
+          pxPerCell: 1,
+          contour: [],
+          contourCount: 0,
+          markerFound: true,
+        });
+      }
     }, []);
     return null;
   });
@@ -48,4 +54,30 @@ describe('LeafAnalyzerProvider', () => {
 
     await waitFor(() => expect(spy).toHaveBeenCalled());
   });
+
+  it('uses fallback analyzer on OpenCV load error', async () => {
+    (global as any).triggerError = true;
+    mockWaitUntilReady.mockImplementation(() => new Promise(() => {}));
+
+    const TestChild = () => {
+      const analyzer = useLeafAnalyzer();
+      return (
+        <Text testID="type">
+          {analyzer instanceof analyzerModule.FallbackAnalyzer ? 'fallback' : 'other'}
+        </Text>
+      );
+    };
+
+    const { queryByText, getByTestId } = render(
+      <LeafAnalyzerProvider>
+        <TestChild />
+      </LeafAnalyzerProvider>
+    );
+
+    await waitFor(() => {
+      expect(queryByText('Инициализация…')).toBeNull();
+      expect(getByTestId('type').props.children).toBe('fallback');
+    });
+  });
 });
+


### PR DESCRIPTION
## Summary
- extend `LeafAnalyzerProvider` to track OpenCV errors
- fallback to `FallbackAnalyzer` and alert when OpenCV fails to load
- hide initialization overlay on failure
- test fallback behaviour for OpenCV load error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f360d9d00833386d8a1f9309d7f4b