### PR TITLE
Fix overlapping live frame capture

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -171,6 +171,7 @@ useEffect(() => {
 
 const captureAndSend = async () => {
   if (!cameraReady || isCapturing || !isMounted) return;
+  if (processingFrame) return;
   try {
     setProcessingFrame(true);
 


### PR DESCRIPTION
## Summary
- avoid concurrent frame processing in `captureAndSend`

## Testing
- `npm test`
- `npm run tsc`


------
https://chatgpt.com/codex/tasks/task_e_68565d9467308333aa097f41bfcafb75