### PR TITLE
feat: detect scale via 5mm marker

### DIFF
--- a/assets/opencv.html
+++ b/assets/opencv.html
@@ -77,31 +77,35 @@
             );
             let contourCount = contours.size();
             let markerFound = false;
-            let calculatedPxPerCell = pxPerCell;
             let markerRect = null;
+            let pixelsPerMm = 0;
 
             for (let i = 0; i < contours.size(); ++i) {
               const cnt = contours.get(i);
               if (cnt.data32S.length >= 8) {
                 const rect = cv.boundingRect(cnt);
                 const aspect = rect.width / rect.height;
-                if (
-                  aspect > 0.8 &&
-                  aspect < 1.2 &&
-                  rect.width > pxPerCell * 0.8 &&
-                  rect.width < pxPerCell * 1.2 &&
-                  rect.height > pxPerCell * 0.8 &&
-                  rect.height < pxPerCell * 1.2
-                ) {
-                  markerFound = true;
-                  calculatedPxPerCell = (rect.width + rect.height) / 2;
-                  markerRect = rect;
-                  break;
+                if (aspect > 0.8 && aspect < 1.2) {
+                  if (!markerRect || rect.width * rect.height < markerRect.width * markerRect.height) {
+                    markerFound = true;
+                    markerRect = rect;
+                  }
                 }
               }
             }
 
-            pxPerCell = calculatedPxPerCell;
+            if (markerFound && markerRect) {
+              pixelsPerMm = (markerRect.width + markerRect.height) / 2 / 5;
+              pxPerCell = pixelsPerMm * 5;
+            } else {
+              src.delete();
+              gray.delete();
+              contours.delete(); hierarchy.delete();
+              window.ReactNativeWebView.postMessage(
+                JSON.stringify({ type: 'error', message: 'Marker not found' })
+              );
+              return;
+            }
 
             if (debug) {
               ctx.lineWidth = 2;

--- a/utils/leaf-analyzer.tsx
+++ b/utils/leaf-analyzer.tsx
@@ -92,6 +92,16 @@ export class OpenCvAnalyzer implements LeafAnalyzer {
     const item = this.queue[0];
     if (!item) return;
     console.error(`OpenCV error: ${message}`);
+    if (message === 'Marker not found') {
+      this.queue.shift();
+      Alert.alert('Ошибка OpenCV', 'Не найден маркер масштаба');
+      item.resolve({ area: NaN, contour: [], contourCount: 0, markerFound: false });
+      if (this.queue.length > 0) {
+        const next = this.queue[0];
+        void this.sendImage(next.base64, next.width, next.height);
+      }
+      return;
+    }
     item.attempts += 1;
     if (item.attempts < MAX_ATTEMPTS) {
       await this.sendImage(item.base64, item.width, item.height);


### PR DESCRIPTION
## Summary
- detect square marker without assuming its size
- compute pixels per mm to convert area
- report error when marker is missing

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685673ce9c1883338e245cbeb07ba29a