### PR TITLE
Fix npm test missing jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start-web-dev": "DEBUG=expo* expo start --web --tunnel",
     "android": "expo run:android",
     "ios": "expo run:ios",
+    "pretest": "node -e \"const fs=require('fs');if(!fs.existsSync('node_modules'))process.exit(1)\" || npm install",
     "test": "jest",
     "tsc": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary
- add `pretest` script in `package.json` so `npm test` installs dependencies if missing

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6856c2a693e4833398ca4be752f86c87