### PR TITLE
Add OpenCV error banner

### DIFF
--- a/__tests__/LeafAnalyzerProvider.test.tsx
+++ b/__tests__/LeafAnalyzerProvider.test.tsx
@@ -60,7 +60,7 @@ describe('LeafAnalyzerProvider', () => {
     mockWaitUntilReady.mockImplementation(() => new Promise(() => {}));
 
     const TestChild = () => {
-      const analyzer = useLeafAnalyzer();
+      const { analyzer } = useLeafAnalyzer();
       return (
         <Text testID="type">
           {analyzer instanceof analyzerModule.OpenCvAnalyzer ? 'opencv' : 'other'}
@@ -77,6 +77,28 @@ describe('LeafAnalyzerProvider', () => {
     await waitFor(() => {
       expect(queryByText('Инициализация…')).toBeNull();
       expect(getByTestId('type').props.children).toBe('opencv');
+    });
+  });
+
+  it('shows error banner on OpenCV load error', async () => {
+    (global as any).triggerError = true;
+    mockWaitUntilReady.mockImplementation(() => new Promise(() => {}));
+
+    const Banner = () => {
+      const { opencvError } = useLeafAnalyzer();
+      return opencvError ? (
+        <Text testID="banner">OpenCV не инициализирован</Text>
+      ) : null;
+    };
+
+    const { getByTestId } = render(
+      <LeafAnalyzerProvider>
+        <Banner />
+      </LeafAnalyzerProvider>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId('banner')).toBeTruthy();
     });
   });
 });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -36,7 +36,7 @@ import { useVolumeButtonListener } from "@/hooks/use-volume-button";
 const { width, height } = Dimensions.get("window");
 
 export default function CameraScreen() {
-  const analyzer = useLeafAnalyzer();
+  const { analyzer, opencvError } = useLeafAnalyzer();
   const [permission, requestPermission] = useCameraPermissions();
   const [locationPermission, requestLocationPermission] = Location.useForegroundPermissions();
   const [facing, setFacing] = useState<CameraType>("back");
@@ -546,6 +546,11 @@ const capturePhoto = async () => {
           </Pressable>
         </View>
       </CameraView>
+      {opencvError && (
+        <View style={styles.errorBanner} pointerEvents="none">
+          <Text style={styles.errorText}>OpenCV не инициализирован</Text>
+        </View>
+      )}
     </View>
   );
 }
@@ -579,6 +584,21 @@ const styles = StyleSheet.create({
   },
   permissionButtonText: {
     color: "#fff",
+    fontSize: 16,
+    fontWeight: "bold",
+  },
+  errorBanner: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    backgroundColor: Colors.status.error,
+    paddingVertical: 10,
+    alignItems: "center",
+    zIndex: 30,
+  },
+  errorText: {
+    color: Colors.text.primary,
     fontSize: 16,
     fontWeight: "bold",
   },

--- a/utils/leaf-analyzer.tsx
+++ b/utils/leaf-analyzer.tsx
@@ -164,7 +164,15 @@ export class OpenCvAnalyzer implements LeafAnalyzer {
   }
 }
 
-const LeafAnalyzerContext = createContext<LeafAnalyzer>(dummyAnalyzer);
+export type LeafAnalyzerContextValue = {
+  analyzer: LeafAnalyzer;
+  opencvError: boolean;
+};
+
+const LeafAnalyzerContext = createContext<LeafAnalyzerContextValue>({
+  analyzer: dummyAnalyzer,
+  opencvError: false,
+});
 
 export const LeafAnalyzerProvider = ({ children }: { children: React.ReactNode }) => {
   const webRef = useRef<OpenCVHandle>(null);
@@ -219,7 +227,7 @@ export const LeafAnalyzerProvider = ({ children }: { children: React.ReactNode }
   };
 
   return (
-    <LeafAnalyzerContext.Provider value={analyzer}>
+    <LeafAnalyzerContext.Provider value={{ analyzer, opencvError }}>
       {children}
       {analyzer instanceof OpenCvAnalyzer && !isOpenCvReady && !opencvError && (
         <View style={styles.initOverlay} pointerEvents="none">
@@ -239,7 +247,8 @@ export const LeafAnalyzerProvider = ({ children }: { children: React.ReactNode }
   );
 };
 
-export const useLeafAnalyzer = () => useContext(LeafAnalyzerContext);
+export const useLeafAnalyzer = (): LeafAnalyzerContextValue =>
+  useContext(LeafAnalyzerContext);
 
 const styles = StyleSheet.create({
   initOverlay: {


### PR DESCRIPTION
## Summary
- extend leaf analyzer context with `opencvError`
- show "OpenCV не инициализирован" banner in camera screen
- test banner display on OpenCV error

## Testing
- `npm run tsc`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856e9eb0f4c8333af18402896c06135