### PR TITLE
fix: skip NaN leaf area in live analysis

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -184,9 +184,11 @@ const captureAndSend = async () => {
     if (!photo?.base64 || !photo?.width || !photo?.height) return;
 
     const area = await analyzer.analyzeArea(photo.uri, true);
-    const contour = await analyzer.findContour(photo.uri);
-    setLeafArea(area);
-    setContourPoints(contour);
+    if (!Number.isNaN(area)) {
+      const contour = await analyzer.findContour(photo.uri);
+      setLeafArea(area);
+      setContourPoints(contour);
+    }
   } catch (error) {
     console.error("Ошибка при анализе кадра:", error);
   } finally {


### PR DESCRIPTION
## Summary
- check area value before updating state during live analysis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856f02634e48333b0e9231c63d4bc9d